### PR TITLE
fix: add warning before navigating away with unsaved files

### DIFF
--- a/src/app/merge-pdf/page.tsx
+++ b/src/app/merge-pdf/page.tsx
@@ -7,6 +7,7 @@ import {Hero} from "@/app/merge-pdf/components/Hero";
 import {FileManager} from "@/components/FileManager";
 import {DownloadModal} from "@/components/DownloadModal";
 import {toast} from "sonner";
+import {useWarnBeforeCloseRefresh} from "@/hooks/useWarnBeforeCloseRefresh";
 
 
 export default function HomePage() {
@@ -31,6 +32,9 @@ export default function HomePage() {
         setIsDownloadModalOpen(false)
         toast("Files merged and downloaded successfully!")
     }
+
+    useWarnBeforeCloseRefresh(files.length > 0, "You have unsaved uploaded files. Are you sure you want to leave this page?")
+
 
     return (
         <div className="min-h-screen bg-navy-50">

--- a/src/hooks/useWarnBeforeCloseRefresh.ts
+++ b/src/hooks/useWarnBeforeCloseRefresh.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react"
+
+export function useWarnBeforeCloseRefresh(enabled: boolean, warningMessage: string) {
+    useEffect(() => {
+        const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+            if (!enabled) return
+            e.preventDefault()
+            e.returnValue = warningMessage
+            return warningMessage
+        }
+
+        window.addEventListener("beforeunload", handleBeforeUnload)
+
+        return () => {
+            window.removeEventListener("beforeunload", handleBeforeUnload)
+        }
+    }, [enabled, warningMessage])
+}


### PR DESCRIPTION

<img width="1296" height="747" alt="image" src="https://github.com/user-attachments/assets/92dc5782-d240-4860-b5b2-5ef5623f6eb4" />


This pull request introduces a new feature to warn users before they refresh or close the page if there are unsaved uploaded files. The main changes include adding a custom React hook, `useWarnBeforeCloseRefresh`, and integrating it into the `HomePage` component.

### New Feature: Warn Before Close/Refresh

* **Custom Hook Implementation**: Added a new hook, `useWarnBeforeCloseRefresh`, in `src/hooks/useWarnBeforeCloseRefresh.ts`. This hook listens for the `beforeunload` event and displays a warning message if the `enabled` parameter is true. It cleans up the event listener when the component unmounts or dependencies change.

* **Integration into HomePage**: Integrated the `useWarnBeforeCloseRefresh` hook into the `HomePage` component in `src/app/merge-pdf/page.tsx`. The hook is enabled when there are unsaved uploaded files (`files.length > 0`), and a custom warning message is provided.

* **Import Statement Update**: Added the import for `useWarnBeforeCloseRefresh` in the `HomePage` component file.