### PR TITLE
tech: integrate Google Analytics tracking scripts in layout and config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,9 @@ const nextConfig: NextConfig = {
     typescript: {
         ignoreBuildErrors: true,
     },
+    env: {
+        NEXT_PUBLIC_GA_ID: process.env.NEXT_PUBLIC_GA_ID,
+    },
 };
 
 export default nextConfig;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import {Toaster} from "sonner";
+import Script from "next/script";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -84,12 +85,24 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
-        <Toaster />
-      </body>
+        <Script
+            strategy="afterInteractive"
+            src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_ID}`}
+        />
+        <Script id="ga-init" strategy="afterInteractive">
+                {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${process.env.NEXT_PUBLIC_GA_ID}');
+      `}
+        </Script>
+          <body
+            className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+          >
+            {children}
+            <Toaster />
+          </body>
     </html>
   );
 }


### PR DESCRIPTION
This pull request introduces Google Analytics (GA) integration into the project by adding environment variable support and embedding the necessary GA scripts. The changes ensure that the GA tracking ID is dynamically loaded from environment variables and the scripts are executed after the page is interactive.

### Google Analytics Integration:

* [`next.config.ts`](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bR11-R13): Added an `env` configuration to include `NEXT_PUBLIC_GA_ID`, enabling the use of the GA tracking ID from environment variables.
* `src/app/layout.tsx`:
  * Imported the `Script` component from `next/script` to handle GA script injection.
  * Embedded the GA script and initialization logic in the `RootLayout` component using the `Script` component with `afterInteractive` strategy. This ensures the GA scripts load only after the page becomes interactive.