### PR TITLE
refactor: remove unused organization schema script from head component

### DIFF
--- a/src/app/head.tsx
+++ b/src/app/head.tsx
@@ -36,12 +36,6 @@ export default function Head() {
                     __html: JSON.stringify(siteSchema),
                 }}
             />
-            <script
-                type="application/ld+json"
-                dangerouslySetInnerHTML={{
-                    __html: JSON.stringify(orgSchema),
-                }}
-            />
         </>
     );
 }


### PR DESCRIPTION
This pull request includes a small change to the `src/app/head.tsx` file. The change removes a `<script>` tag that included `orgSchema` as structured data in JSON-LD format.