### PR TITLE
fix: handle filenames without extension

### DIFF
--- a/src/hooks/useTruncatedFilename.ts
+++ b/src/hooks/useTruncatedFilename.ts
@@ -1,22 +1,24 @@
-
-
 const useTruncatedFilename = () => {
     const truncate = (filename: string, maxLength: number = 40): string => {
-        const ext = filename.split('.').pop()
-        const nameWithoutExt = filename.replace(/\.[^/.]+$/, "")
+        const dotIndex = filename.lastIndexOf(".")
+        const hasExtension = dotIndex !== -1
+        const ext = hasExtension ? filename.slice(dotIndex + 1) : ""
+        const nameWithoutExt = hasExtension ? filename.slice(0, dotIndex) : filename
 
         if (filename.length <= maxLength) return filename
 
-        const keepStart = Math.floor((maxLength - ext!.length - 5) / 2)
-        const keepEnd = Math.ceil((maxLength - ext!.length - 5) / 2)
+        const reserved = 3 + (hasExtension ? ext.length + 1 : 0) // ellipsis + optional dot and extension
+        const keepStart = Math.floor((maxLength - reserved) / 2)
+        const keepEnd = Math.ceil((maxLength - reserved) / 2)
 
         const start = nameWithoutExt.slice(0, keepStart)
         const end = nameWithoutExt.slice(-keepEnd)
 
-        return `${start}...${end}.${ext}`
+        return hasExtension ? `${start}...${end}.${ext}` : `${start}...${end}`
     }
 
     return { truncate }
 }
 
-export default useTruncatedFilename;
+export default useTruncatedFilename
+


### PR DESCRIPTION
## Summary
- prevent duplicate extensions when truncating filenames lacking a period
- account for optional extension when calculating truncation lengths

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, no-unescaped-entities, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6896c1100834832a9e4869275c9ae5de