### PR TITLE
fix(split-pdf): replace static `pdfjs-dist` import with dynamic import

### DIFF
--- a/src/app/split-pdf/page.tsx
+++ b/src/app/split-pdf/page.tsx
@@ -16,13 +16,16 @@ import {PageSelectionHeader} from "@/app/split-pdf/components/PageSelectionHeade
 import {SplitPdfAction} from "@/app/split-pdf/components/SplitPdfAction";
 import {FAQ} from "@/components/FAQ";
 import {FaqSplitPdf} from "@/components/faqs/FaqSplitPdf";
+import dynamic from "next/dynamic";
 
 
 export default function SplitPdfPage() {
     const router = useRouter()
     const { state, loadPdf, clearAll, toggle, setAll, invert, splitPdf, includedCount } = useSplitPdf()
     const [columns, setColumns] = useState<1 | 2 | 3 | 4 | 5 >(2)
-
+    const SplitGrid = dynamic(() => import("./components/SplitGrid").then(m => m.SplitGrid), {
+        ssr: false,
+    });
     return (
         <div className="min-h-screen bg-background">
             <Header />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched PDF handling to load worker and library dynamically to reduce upfront resource usage and improve initialization sequencing.
  * Updated component loading to use dynamic, client-only import to improve rendering performance.
  * Improved lifecycle and cleanup behavior, adding cancellation handling and more robust error handling during PDF operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->